### PR TITLE
STT streaming via AssemblyAI

### DIFF
--- a/packages/web/src/static/index.html
+++ b/packages/web/src/static/index.html
@@ -64,15 +64,81 @@
         const logDiv = document.getElementById('log');
         
         let ws;
-        let mediaRecorder;
         let audioContext;
+        let workletNode;
+        let mediaStream;
         let nextStartTime = 0;
+
+        const TARGET_SAMPLE_RATE = 16000;
 
         function log(msg) {
             const p = document.createElement('div');
             p.textContent = `[${new Date().toLocaleTimeString()}] ${msg}`;
             logDiv.appendChild(p);
             logDiv.scrollTop = logDiv.scrollHeight;
+        }
+
+        // AudioWorkletProcessor code as a string (will be loaded via Blob URL)
+        const workletCode = `
+            class PCMProcessor extends AudioWorkletProcessor {
+                constructor() {
+                    super();
+                    this.buffer = [];
+                    this.targetSampleRate = 16000;
+                    // sampleRate is the AudioContext's sample rate (usually 48000)
+                    this.resampleRatio = sampleRate / this.targetSampleRate;
+                    this.resampleBuffer = [];
+                    this.resampleIndex = 0;
+                }
+
+                process(inputs) {
+                    const input = inputs[0];
+                    if (!input || !input[0]) return true;
+
+                    const channelData = input[0]; // Mono or first channel
+
+                    // Downsample from native rate to 16kHz
+                    for (let i = 0; i < channelData.length; i++) {
+                        this.resampleIndex += 1;
+                        if (this.resampleIndex >= this.resampleRatio) {
+                            this.resampleIndex -= this.resampleRatio;
+                            
+                            // Convert Float32 [-1, 1] to Int16 [-32768, 32767]
+                            let sample = channelData[i];
+                            sample = Math.max(-1, Math.min(1, sample));
+                            const int16 = sample < 0 ? sample * 0x8000 : sample * 0x7FFF;
+                            this.buffer.push(int16);
+                        }
+                    }
+
+                    // Send chunks of ~100ms worth of audio (1600 samples at 16kHz)
+                    const CHUNK_SIZE = 1600;
+                    while (this.buffer.length >= CHUNK_SIZE) {
+                        const chunk = this.buffer.splice(0, CHUNK_SIZE);
+                        const int16Array = new Int16Array(chunk);
+                        this.port.postMessage(int16Array.buffer, [int16Array.buffer]);
+                    }
+
+                    return true;
+                }
+            }
+
+            registerProcessor('pcm-processor', PCMProcessor);
+        `;
+
+        async function setupAudioWorklet() {
+            // Create AudioContext
+            audioContext = new (window.AudioContext || window.webkitAudioContext)();
+            
+            // Create Blob URL for the worklet
+            const blob = new Blob([workletCode], { type: 'application/javascript' });
+            const workletUrl = URL.createObjectURL(blob);
+            
+            // Load the worklet module
+            await audioContext.audioWorklet.addModule(workletUrl);
+            URL.revokeObjectURL(workletUrl);
+            
+            log(`AudioContext sample rate: ${audioContext.sampleRate}Hz`);
         }
 
         startBtn.onclick = async () => {
@@ -89,19 +155,43 @@
                 stopBtn.disabled = false;
 
                 try {
-                    const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+                    // Setup AudioWorklet if not already done
+                    if (!audioContext) {
+                        await setupAudioWorklet();
+                    }
+                    
+                    if (audioContext.state === 'suspended') {
+                        await audioContext.resume();
+                    }
+
+                    // Get microphone stream
+                    mediaStream = await navigator.mediaDevices.getUserMedia({ 
+                        audio: {
+                            echoCancellation: true,
+                            noiseSuppression: true,
+                            autoGainControl: true,
+                        }
+                    });
                     log('Microphone access granted');
                     
-                    mediaRecorder = new MediaRecorder(stream, { mimeType: 'audio/webm;codecs=opus' });
+                    // Create source from microphone
+                    const source = audioContext.createMediaStreamSource(mediaStream);
                     
-                    mediaRecorder.ondataavailable = (event) => {
-                        if (event.data.size > 0 && ws.readyState === WebSocket.OPEN) {
+                    // Create worklet node
+                    workletNode = new AudioWorkletNode(audioContext, 'pcm-processor');
+                    
+                    // Handle PCM data from worklet
+                    workletNode.port.onmessage = (event) => {
+                        if (ws && ws.readyState === WebSocket.OPEN) {
                             ws.send(event.data);
                         }
                     };
-
-                    mediaRecorder.start(250); // Send chunks every 250ms
-                    log('Recording started');
+                    
+                    // Connect: microphone -> worklet
+                    source.connect(workletNode);
+                    // Don't connect to destination (we don't want to hear ourselves)
+                    
+                    log('Streaming PCM audio (16kHz, 16-bit, mono)');
                 } catch (err) {
                     console.error(err);
                     log('Error accessing microphone: ' + err.message);
@@ -111,11 +201,8 @@
             };
 
             ws.onmessage = async (event) => {
-                log('Received message: ' + event.data);
                 // We expect audio buffers from the server (PCM 16000Hz 16-bit Mono)
                 if (event.data instanceof ArrayBuffer) {
-                    // log(`Received audio chunk (${event.data.byteLength} bytes)`);
-                    
                     if (!audioContext) {
                         audioContext = new (window.AudioContext || window.webkitAudioContext)();
                     }
@@ -149,7 +236,6 @@
 
                         const now = audioContext.currentTime;
                         // Add a small jitter buffer (50ms) if we are starting fresh or fell behind
-                        // This helps prevent "clicks" between chunks if they arrive with slight variance
                         const bufferingDelay = 0.05; 
                         
                         let startTime = nextStartTime;
@@ -182,13 +268,19 @@
 
         stopBtn.onclick = () => {
             log('Stopping recording...');
-            if (mediaRecorder && mediaRecorder.state !== 'inactive') {
-                mediaRecorder.stop();
-                mediaRecorder.stream.getTracks().forEach(track => track.stop());
+            
+            // Disconnect worklet
+            if (workletNode) {
+                workletNode.disconnect();
+                workletNode = null;
+            }
+            
+            // Stop media stream tracks
+            if (mediaStream) {
+                mediaStream.getTracks().forEach(track => track.stop());
+                mediaStream = null;
             }
 
-            // Do NOT close WS here immediately if we want to receive the response.
-            // But currently the server closes WS after sending response.
             resetUI();
         };
 
@@ -196,7 +288,7 @@
             startBtn.disabled = false;
             stopBtn.disabled = true;
             // We do NOT reset nextStartTime here because audio might still be queued playing!
-            // We do NOT close audioContext because that kills pending audio.
+            // We do NOT close audioContext because that kills pending audio and worklet.
         }
     </script>
 </body>

--- a/packages/web/src/transforms/AssemblyAISTTTransform.ts
+++ b/packages/web/src/transforms/AssemblyAISTTTransform.ts
@@ -1,0 +1,208 @@
+import querystring from "querystring";
+import WebSocket from "ws";
+
+interface AssemblyAISTTOptions {
+  apiKey: string;
+  sampleRate?: number;
+  formatTurns?: boolean;
+}
+
+interface BeginMessage {
+  type: "Begin";
+  id: string;
+  expires_at: number;
+}
+
+interface TurnMessage {
+  type: "Turn";
+  transcript: string;
+  turn_is_formatted: boolean;
+}
+
+interface TerminationMessage {
+  type: "Termination";
+  audio_duration_seconds: number;
+  session_duration_seconds: number;
+}
+
+type AssemblyAIMessage = BeginMessage | TurnMessage | TerminationMessage;
+
+/**
+ * AssemblyAI Real-Time Streaming STT Transform (v3 API)
+ *
+ * Input: PCM 16-bit audio buffer
+ * Output: Transcribed text string (final/formatted transcripts only)
+ *
+ * Uses AssemblyAI's WebSocket-based real-time transcription API
+ * for significantly lower latency than batch-based STT.
+ */
+export class AssemblyAISTTTransform extends TransformStream<Buffer, string> {
+  constructor(options: AssemblyAISTTOptions) {
+    const { apiKey, sampleRate = 16000, formatTurns = true } = options;
+
+    let ws: WebSocket | null = null;
+    let connectionPromise: Promise<void> | null = null;
+    let activeController: TransformStreamDefaultController<string> | null =
+      null;
+    let sessionId: string | null = null;
+
+    const resetConnection = () => {
+      if (ws) {
+        try {
+          ws.close();
+        } catch (e) {
+          console.error("AssemblyAI: Error closing WebSocket:", e);
+        }
+        ws = null;
+      }
+      connectionPromise = null;
+      sessionId = null;
+    };
+
+    const ensureConnection = (): Promise<void> => {
+      if (ws && ws.readyState === WebSocket.OPEN) {
+        return Promise.resolve();
+      }
+      if (connectionPromise) return connectionPromise;
+
+      connectionPromise = new Promise((resolve, reject) => {
+        const params = querystring.stringify({
+          sample_rate: sampleRate,
+          format_turns: formatTurns,
+        });
+
+        const url = `wss://streaming.assemblyai.com/v3/ws?${params}`;
+        console.log(`AssemblyAI: Connecting to v3 streaming API...`);
+
+        ws = new WebSocket(url, {
+          headers: {
+            Authorization: apiKey,
+          },
+        });
+
+        ws.on("open", () => {
+          console.log("AssemblyAI: WebSocket connected");
+        });
+
+        ws.on("message", (data: Buffer) => {
+          try {
+            const message = JSON.parse(data.toString()) as AssemblyAIMessage;
+
+            switch (message.type) {
+              case "Begin":
+                sessionId = message.id;
+                console.log(
+                  `AssemblyAI: Session started (${sessionId}), expires at ${new Date(message.expires_at * 1000).toISOString()}`
+                );
+                resolve();
+                break;
+
+              case "Turn":
+                if (message.turn_is_formatted) {
+                  // Final/formatted transcript - send to pipeline
+                  if (message.transcript && message.transcript.trim().length > 0) {
+                    console.log(`AssemblyAI [final]: "${message.transcript}"`);
+                    if (activeController) {
+                      activeController.enqueue(message.transcript);
+                    }
+                  }
+                } else {
+                  // Partial transcript - log for debugging
+                  if (message.transcript) {
+                    console.log(`AssemblyAI [partial]: "${message.transcript}"`);
+                  }
+                }
+                break;
+
+              case "Termination":
+                console.log(
+                  `AssemblyAI: Session terminated (audio: ${message.audio_duration_seconds}s, session: ${message.session_duration_seconds}s)`
+                );
+                resetConnection();
+                break;
+
+              default: {
+                // Handle any errors or unknown message types
+                const msg = message as any;
+                if (msg.error) {
+                  console.error("AssemblyAI error:", msg.error);
+                }
+              }
+            }
+          } catch (e) {
+            console.error("AssemblyAI: Error parsing message:", e);
+          }
+        });
+
+        ws.on("error", (err) => {
+          console.error("AssemblyAI WebSocket Error:", err);
+          resetConnection();
+          reject(err);
+        });
+
+        ws.on("close", (code, reason) => {
+          console.log(
+            `AssemblyAI: WebSocket closed (code: ${code}, reason: ${reason})`
+          );
+          resetConnection();
+        });
+
+        // Timeout for connection
+        setTimeout(() => {
+          if (!sessionId) {
+            reject(new Error("AssemblyAI: Connection timeout"));
+            resetConnection();
+          }
+        }, 10000);
+      });
+
+      return connectionPromise;
+    };
+
+    super({
+      start(controller) {
+        activeController = controller;
+      },
+
+      async transform(chunk) {
+        try {
+          await ensureConnection();
+
+          if (ws && ws.readyState === WebSocket.OPEN) {
+            // v3 API: Send raw PCM audio bytes directly (not base64)
+            ws.send(chunk);
+          } else {
+            console.warn("AssemblyAI: WebSocket not open, dropping audio chunk");
+          }
+        } catch (err) {
+          console.error("AssemblyAI: Error in transform:", err);
+        }
+      },
+
+      async flush() {
+        console.log("AssemblyAI: Flushing stream...");
+        if (ws && ws.readyState === WebSocket.OPEN) {
+          // v3 API: Send terminate message
+          ws.send(JSON.stringify({ type: "Terminate" }));
+
+          // Wait for termination or timeout
+          await new Promise<void>((resolve) => {
+            const checkClosed = setInterval(() => {
+              if (!ws || ws.readyState !== WebSocket.OPEN) {
+                clearInterval(checkClosed);
+                resolve();
+              }
+            }, 100);
+
+            // Timeout after 3 seconds
+            setTimeout(() => {
+              clearInterval(checkClosed);
+              resetConnection();
+              resolve();
+            }, 3000);
+          });
+        }
+      },
+    });
+  }
+}

--- a/packages/web/src/transforms/index.ts
+++ b/packages/web/src/transforms/index.ts
@@ -1,5 +1,6 @@
 export * from "./AgentTransform";
 export * from "./AIMessageChunkTransform";
+export * from "./AssemblyAISTTTransform";
 export * from "./ElevenLabsTTSTransform";
 export * from "./openai";
 export * from "./SentenceChunkerTransform";


### PR DESCRIPTION
This PR reduces end-to-end latency in the voice sandwich demo by replacing batch-based STT with streaming STT and eliminating unnecessary audio transcoding steps.

### Changes

#### Client-side Audio Capture
- Replaced `MediaRecorder` (Opus/WebM) with `AudioWorklet` for raw PCM capture
- Audio is now downsampled to 16kHz and streamed as Int16 PCM directly
- Reduced chunk interval from 250ms to ~100ms

#### New Pipeline Flow
```
Browser (PCM) → WebSocket → AssemblyAI STT → Agent → SentenceChunker → ElevenLabs TTS
```

### Latency Impact

| Component | Before | After |
|-----------|--------|-------|
| Audio encoding | Opus (~10-20ms) | None |
| Server decoding | FFmpeg subprocess | None |
| STT | Whisper batch (~1-2s) | AssemblyAI streaming (~200-500ms) |
| TTS trigger | Wait for full response | Per-sentence |

