### PR TITLE
feat: add hang up tool to allow agent to end the call

### DIFF
--- a/packages/graphs/src/ordering-agent.ts
+++ b/packages/graphs/src/ordering-agent.ts
@@ -38,15 +38,38 @@ const confirmOrder = tool(
   }
 );
 
+const hangUp = tool(
+  ({ reason }) => {
+    return `Call ended: ${reason}`;
+  },
+  {
+    name: "hang_up",
+    description:
+      "End the call and hang up the connection. Use this when the conversation has naturally concluded, the customer says goodbye, or explicitly asks to end the call.",
+    schema: z.object({
+      reason: z
+        .string()
+        .describe("Brief reason for ending the call (e.g., 'Order complete', 'Customer said goodbye')."),
+    }),
+  }
+);
+
 const SYSTEM_PROMPT = `
 You are a helpful sandwich shop assistant. Your goal is to take the user's order. Be concise and friendly. Available toppings: lettuce, tomato, onion, pickles, mayo, mustard. Available meats: turkey, ham, roast beef. Available cheeses: swiss, cheddar, provolone.
+
+IMPORTANT: You MUST call the hang_up tool in these situations:
+- After confirming an order and the customer indicates they're done (says "no" to additional items, says goodbye, etc.)
+- When the customer explicitly says goodbye, thanks you, or indicates the conversation is over
+- When the customer says phrases like "that's it", "that's all", "I'm good", "bye", "thanks", "thank you"
+
+Always call hang_up AFTER giving your final farewell message. Do not just respond with text - you must use the tool to properly end the call.
 `;
 
 export const agent = createAgent({
   model: new ChatGoogleGenerativeAI({
     model: "gemini-2.5-flash",
   }),
-  tools: [addToOrder, confirmOrder],
+  tools: [addToOrder, confirmOrder, hangUp],
   systemPrompt: SYSTEM_PROMPT,
   checkpointer: new MemorySaver(),
 });

--- a/packages/web/src/transforms/ElevenLabsTTSTransform.ts
+++ b/packages/web/src/transforms/ElevenLabsTTSTransform.ts
@@ -16,6 +16,11 @@ interface ElevenLabsOptions {
    * Callback called when TTS output is interrupted (for barge-in)
    */
   onInterrupt?: () => void;
+  /**
+   * Callback called when audio generation is complete (isFinal received from ElevenLabs).
+   * Useful for knowing when all audio has been sent for a turn.
+   */
+  onAudioComplete?: () => void;
 }
 
 export class ElevenLabsTTSTransform extends TransformStream<string, Buffer> {
@@ -285,6 +290,8 @@ export class ElevenLabsTTSTransform extends TransformStream<string, Buffer> {
                     finalResolve();
                     finalResolve = null;
                   }
+                  // Notify that audio generation is complete
+                  options.onAudioComplete?.();
                 }, 100);
               } else {
                 console.log("ElevenLabs: Ignoring isFinal (no EOS sent yet)");


### PR DESCRIPTION
This adds a tool to allow the agent to hang up the call. Unfortunately it often fails due to a bug in our Google package:

```
AssemblyAI [partial]: "nope that's"
AssemblyAI [partial]: "nope that's it"
AssemblyAI [final]: "Nope, that's it."
Agent processing started, filler timer activated
ElevenLabs: Connecting...
ElevenLabs: WebSocket connected
ElevenLabs: Sending first token: "Great..."
[AgentTransform] Hang up tool called: Call ended: Order complete
[AgentTransform] Agent initiated hang up, waiting for audio to complete: Call ended: Order complete
No parts found in candidate content {
  "role": "model"
}
Pipeline error: Error: Received empty response from chat model call.
    at ChatGoogleGenerativeAI._generateUncached (/Users/christian.bromann/Sites/LangChain/voice-sandwich-demo/node_modules/.pnpm/@langchain+core@1.0.6_openai@6.9.1_ws@8.18.3_zod@4.1.12_/node_modules/@langchain/core/src/language_models/chat_models.ts:514:17)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async ChatGoogleGenerativeAI.invoke (/Users/christian.bromann/Sites/LangChain/voice-sandwich-demo/node_modules/.pnpm/@langchain+core@1.0.6_openai@6.9.1_ws@8.18.3_zod@4.1.12_/node_modules/@langchain/core/src/language_models/chat_models.ts:278:20)
    at async RunnableSequence.invoke (/Users/christian.bromann/Sites/LangChain/voice-sandwich-demo/node_modules/.pnpm/@langchain+core@1.0.6_openai@6.9.1_ws@8.18.3_zod@4.1.12_/node_modules/@langchain/core/src/runnables/base.ts:1910:21)
```